### PR TITLE
Correction PHP Notice

### DIFF
--- a/core/class/synologyapi.class.php
+++ b/core/class/synologyapi.class.php
@@ -334,7 +334,8 @@ $arrContextOptions=array(
 	{
 		parse_str(str_replace("?", "", $parametresAPI), $outputArray);
 		$API=$outputArray['api'];
-		$versionSiPresente=$outputArray['version'];
+		if(array_key_exists('version', $outputArray)){$versionSiPresente=$outputArray['version'];}
+		else{$versionSiPresente=0;}
  /*
 	log::add('synologyapi', 'debug', '[parametresAPI] '.$parametresAPI);
 	log::add('synologyapi', 'debug', 'lancement  recupereDonneesJson '.$API);


### PR DESCRIPTION
Ligne 337, récupération de l'argument "version". si l'argument n'est pas passé, il n'existe pas et la ligne génère un PHP Notice.